### PR TITLE
chore: add localhost link

### DIFF
--- a/packages/app/server/index.ts
+++ b/packages/app/server/index.ts
@@ -17,6 +17,7 @@ export default async (directory: string, webpackConfigPath?: string, tsConfigPat
   app.use(express.static(join(__dirname, '../app')));
 
   app.listen(4444, () => {
+    console.log('👀 vuensight: http://localhost:4444');
     console.log('server is listening on port 4444');
   });
 };


### PR DESCRIPTION
When using vscode terminal, you can directly use the shortcut key Alt + left mouse button to click log to call up the browser