### PR TITLE
Fix regex for .vue files

### DIFF
--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vuensight/parser",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "dist/index.js",
   "description": "This parser extracts information regarding the dependencies and their used props, events and slots of a given Vue.js project.",
   "scripts": {

--- a/packages/parser/src/vue/dependencies.ts
+++ b/packages/parser/src/vue/dependencies.ts
@@ -27,7 +27,7 @@ export const findDependencies = (
     cruiseResult = cruise(
         [directory],
         {
-          includeOnly: `.${fileType}`,
+          includeOnly: `^.*.(${fileType})$`,
           exclude: ['node_modules'],
           doNotFollow: {
              path: 'node_modules',


### PR DESCRIPTION
Only .vue files are matched and cruised now. Previously
also dependencies with 'vue' in their name have been
recognized.

Resolves #31